### PR TITLE
ADD call method

### DIFF
--- a/pytorch_wrapper/system.py
+++ b/pytorch_wrapper/system.py
@@ -514,6 +514,9 @@ class System(object):
 
         return results
 
+    def __call__(self, *args, **kwargs):
+        return self.model(*args, **kwargs)
+
 
 class _Trainer(object):
 


### PR DESCRIPTION
Add __call__ built-in method in order the make it possible to call `system` like any other pytorch module. This way, one could use system to load his model and use it for making predictions on one data point without creating a loader.